### PR TITLE
tests: add initial test suite

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -2,6 +2,7 @@ pub const SYSFS_MOUNT_PATH: &str = "/sys";
 pub const SYSFS_DEVICE_PATH: &str = "/sys/bus/usb/devices";
 
 pub const USBFS_MAX_DRIVER_NAME: usize = 255;
+pub const USBFS_MAX_DRIVER_NAME_FFI: usize = 256;
 pub const MAX_BULK_BUFFER_LENGTH: usize = 16384;
 pub const MAX_CTRL_BUFFER_LENGTH: usize = 4096;
 pub const MAX_ISO_PACKETS_PER_URB: usize = 128;

--- a/src/ioctl.rs
+++ b/src/ioctl.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 ioctl_readwrite!(usbfs_control, b'U', 0, UsbfsCtrlTransferFfi);
-ioctl_read!(usbfs_setinterface, b'U', 4, UsbfsSetInterface); 
+ioctl_read!(usbfs_setinterface, b'U', 4, UsbfsSetInterface);
 ioctl_read!(usbfs_setconfiguration, b'U', 5, u32);
 ioctl_write_ptr!(usbfs_getdriver, b'U', 8, UsbfsGetDriver);
 ioctl_read!(usbfs_submiturb, b'U', 10, UrbFfi);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #[macro_use]
 extern crate nix;
 
+mod constants;
 mod error;
 mod ioctl;
-mod constants;
 mod types;
 
 pub use constants::*;
@@ -11,9 +11,9 @@ pub use error::*;
 
 pub use types::cap::UsbfsCap;
 pub use types::connect_info::UsbfsConnectInfo;
-pub use types::disconnect_claim::{UsbfsDisconnectClaim, UsbfsDisconnectClaimFlag};
 pub use types::ctrl_transfer::UsbfsCtrlTransfer;
-pub use types::driver::UsbfsGetDriver;
+pub use types::disconnect_claim::{UsbfsDisconnectClaim, UsbfsDisconnectClaimFlag};
+pub use types::driver::{DriverName, UsbfsGetDriver};
 pub use types::interface::UsbfsSetInterface;
 pub use types::ioctl::{UsbfsIoctl, UsbfsIoctlData};
 pub use types::iso_packet_desc::UsbfsIsoPacketDesc;
@@ -28,7 +28,9 @@ use types::{UrbFfi, UsbfsCtrlTransferFfi, UsbfsIoctlFfi, UsbfsStreamsFfi};
 /// The user is responsible for setting all the relevant [UsbfsCtrlTransfer] fields.
 pub fn usbfs_control(fd: i32, ctrl: &mut UsbfsCtrlTransfer) -> Result<()> {
     let mut ctrl = UsbfsCtrlTransferFfi::from(ctrl);
-    unsafe { ioctl::usbfs_control(fd, &mut ctrl)?; }
+    unsafe {
+        ioctl::usbfs_control(fd, &mut ctrl)?;
+    }
     Ok(())
 }
 
@@ -36,13 +38,17 @@ pub fn usbfs_control(fd: i32, ctrl: &mut UsbfsCtrlTransfer) -> Result<()> {
 ///
 /// The user is responsible for setting all the relevant [UsbfsSetInterface] fields.
 pub fn usbfs_set_interface(fd: i32, set_interface: &mut UsbfsSetInterface) -> Result<()> {
-    unsafe { ioctl::usbfs_setinterface(fd, set_interface)?; }
+    unsafe {
+        ioctl::usbfs_setinterface(fd, set_interface)?;
+    }
     Ok(())
 }
 
 /// USBFS Set Configuration
 pub fn usbfs_set_configuration(fd: i32, config: &mut u32) -> Result<()> {
-    unsafe { ioctl::usbfs_setconfiguration(fd, config)?; }
+    unsafe {
+        ioctl::usbfs_setconfiguration(fd, config)?;
+    }
     Ok(())
 }
 
@@ -50,7 +56,9 @@ pub fn usbfs_set_configuration(fd: i32, config: &mut u32) -> Result<()> {
 ///
 /// The user is responsible for setting all the relevant [UsbfsGetDriver] fields.
 pub fn usbfs_get_driver(fd: i32, get_driver: &mut UsbfsGetDriver) -> Result<()> {
-    unsafe { ioctl::usbfs_getdriver(fd, get_driver)?; }
+    unsafe {
+        ioctl::usbfs_getdriver(fd, get_driver)?;
+    }
     Ok(())
 }
 
@@ -59,13 +67,17 @@ pub fn usbfs_get_driver(fd: i32, get_driver: &mut UsbfsGetDriver) -> Result<()> 
 /// The user is responsible for setting all the relevant [Urb] fields.
 pub fn usbfs_submit_urb(fd: i32, urb: &mut Urb) -> Result<()> {
     let mut urb_ffi = UrbFfi::from(urb);
-    unsafe { ioctl::usbfs_submiturb(fd, &mut urb_ffi)?; }
+    unsafe {
+        ioctl::usbfs_submiturb(fd, &mut urb_ffi)?;
+    }
     Ok(())
 }
 
 /// USBFS Discard URB
 pub fn usbfs_discard_urb(fd: i32) -> Result<()> {
-    unsafe { ioctl::usbfs_discardurb(fd)?; }
+    unsafe {
+        ioctl::usbfs_discardurb(fd)?;
+    }
     Ok(())
 }
 
@@ -73,20 +85,26 @@ pub fn usbfs_discard_urb(fd: i32) -> Result<()> {
 ///
 /// The user is responsible for setting all the relevant [Urb] fields.
 pub fn usbfs_reap_urb_ndelay(fd: i32, urb: &mut Urb) -> Result<()> {
-    let mut urb_ffi = UrbFfi::from(urb);
-    unsafe { ioctl::usbfs_reapurbndelay(fd, &mut urb_ffi)?; }
+    let urb_ffi = UrbFfi::from(urb);
+    unsafe {
+        ioctl::usbfs_reapurbndelay(fd, &urb_ffi)?;
+    }
     Ok(())
 }
 
-/// USBFS Claim Interface 
+/// USBFS Claim Interface
 pub fn usbfs_claim_interface(fd: i32, iface: &mut u32) -> Result<()> {
-    unsafe { ioctl::usbfs_claiminterface(fd, iface)?; }
+    unsafe {
+        ioctl::usbfs_claiminterface(fd, iface)?;
+    }
     Ok(())
 }
 
-/// USBFS Release Interface 
+/// USBFS Release Interface
 pub fn usbfs_release_interface(fd: i32, iface: &mut u32) -> Result<()> {
-    unsafe { ioctl::usbfs_releaseinterface(fd, iface)?; }
+    unsafe {
+        ioctl::usbfs_releaseinterface(fd, iface)?;
+    }
     Ok(())
 }
 
@@ -94,7 +112,9 @@ pub fn usbfs_release_interface(fd: i32, iface: &mut u32) -> Result<()> {
 ///
 /// The user is responsible for setting all the relevant [UsbfsConnectInfo] fields.
 pub fn usbfs_connect_info(fd: i32, info: &mut UsbfsConnectInfo) -> Result<()> {
-    unsafe { ioctl::usbfs_connectinfo(fd, info)?; }
+    unsafe {
+        ioctl::usbfs_connectinfo(fd, info)?;
+    }
     Ok(())
 }
 
@@ -103,37 +123,49 @@ pub fn usbfs_connect_info(fd: i32, info: &mut UsbfsConnectInfo) -> Result<()> {
 /// The user is responsible for setting all the relevant [UsbfsIoctl] fields.
 pub fn usbfs_ioctl(fd: i32, ioctl: &mut UsbfsIoctl) -> Result<()> {
     let mut ioctl_ffi = UsbfsIoctlFfi::from(ioctl);
-    unsafe { ioctl::usbfs_ioctl(fd, &mut ioctl_ffi)?; }
+    unsafe {
+        ioctl::usbfs_ioctl(fd, &mut ioctl_ffi)?;
+    }
     Ok(())
 }
 
 /// USBFS Reset
 pub fn usbfs_reset(fd: i32) -> Result<()> {
-    unsafe { ioctl::usbfs_reset(fd)?; }
+    unsafe {
+        ioctl::usbfs_reset(fd)?;
+    }
     Ok(())
 }
 
-/// USBFS Clear Halt 
+/// USBFS Clear Halt
 pub fn usbfs_clear_halt(fd: i32, iface: &mut u32) -> Result<()> {
-    unsafe { ioctl::usbfs_clear_halt(fd, iface)?; }
+    unsafe {
+        ioctl::usbfs_clear_halt(fd, iface)?;
+    }
     Ok(())
 }
 
 /// USBFS Disconnect
 pub fn usbfs_disconnect(fd: i32) -> Result<()> {
-    unsafe { ioctl::usbfs_disconnect(fd)?; }
+    unsafe {
+        ioctl::usbfs_disconnect(fd)?;
+    }
     Ok(())
 }
 
 /// USBFS Connect
 pub fn usbfs_connect(fd: i32) -> Result<()> {
-    unsafe { ioctl::usbfs_connect(fd)?; }
+    unsafe {
+        ioctl::usbfs_connect(fd)?;
+    }
     Ok(())
 }
 
 /// USBFS Get Capabilities
 pub fn usbfs_get_capabilities(fd: i32, iface: &mut u32) -> Result<()> {
-    unsafe { ioctl::usbfs_get_capabilities(fd, iface)?; }
+    unsafe {
+        ioctl::usbfs_get_capabilities(fd, iface)?;
+    }
     Ok(())
 }
 
@@ -141,7 +173,9 @@ pub fn usbfs_get_capabilities(fd: i32, iface: &mut u32) -> Result<()> {
 ///
 /// The user is responsible for setting all the relevant [UsbfsDisconnectClaim] fields.
 pub fn usbfs_disconnect_claim(fd: i32, claim: &mut UsbfsDisconnectClaim) -> Result<()> {
-    unsafe { ioctl::usbfs_disconnect_claim(fd, claim)?; }
+    unsafe {
+        ioctl::usbfs_disconnect_claim(fd, claim)?;
+    }
     Ok(())
 }
 
@@ -152,7 +186,9 @@ pub fn usbfs_disconnect_claim(fd: i32, claim: &mut UsbfsDisconnectClaim) -> Resu
 /// The user is responsible for setting all the relevant [UsbfsStreams] fields.
 pub fn usbfs_alloc_streams(fd: i32, streams: &mut UsbfsStreams) -> Result<()> {
     let mut streams_ffi = UsbfsStreamsFfi::from(streams);
-    unsafe { ioctl::usbfs_alloc_streams(fd, &mut streams_ffi)?; }
+    unsafe {
+        ioctl::usbfs_alloc_streams(fd, &mut streams_ffi)?;
+    }
     Ok(())
 }
 
@@ -163,18 +199,24 @@ pub fn usbfs_alloc_streams(fd: i32, streams: &mut UsbfsStreams) -> Result<()> {
 /// The user is responsible for setting all the relevant [UsbfsStreams] fields.
 pub fn usbfs_free_streams(fd: i32, streams: &mut UsbfsStreams) -> Result<()> {
     let mut streams_ffi = UsbfsStreamsFfi::from(streams);
-    unsafe { ioctl::usbfs_free_streams(fd, &mut streams_ffi)?; }
+    unsafe {
+        ioctl::usbfs_free_streams(fd, &mut streams_ffi)?;
+    }
     Ok(())
 }
 
 /// USBFS Drop Privileges
 pub fn usbfs_drop_privileges(fd: i32, privileges: u64) -> Result<()> {
-    unsafe { ioctl::usbfs_drop_privileges(fd, privileges)?; }
+    unsafe {
+        ioctl::usbfs_drop_privileges(fd, privileges)?;
+    }
     Ok(())
 }
 
 /// USBFS Get Speed
 pub fn usbfs_get_speed(fd: i32) -> Result<()> {
-    unsafe { ioctl::usbfs_get_speed(fd)?; }
+    unsafe {
+        ioctl::usbfs_get_speed(fd)?;
+    }
     Ok(())
 }

--- a/src/types/connect_info.rs
+++ b/src/types/connect_info.rs
@@ -11,10 +11,12 @@ pub struct UsbfsConnectInfo {
 impl UsbfsConnectInfo {
     /// Creates a new [UsbfsConnectInfo].
     pub const fn new() -> Self {
-        Self {
-            devnum: 0,
-            slow: 0,
-        }
+        Self { devnum: 0, slow: 0 }
+    }
+
+    /// Creates a new [UsbfsConnectInfo] from the provided parameter.
+    pub const fn create(devnum: u32, slow: u8) -> Self {
+        Self { devnum, slow }
     }
 
     /// Gets the device number.
@@ -22,9 +24,31 @@ impl UsbfsConnectInfo {
         self.devnum
     }
 
+    /// Sets the device number.
+    pub fn set_devnum(&mut self, devnum: u32) {
+        self.devnum = devnum;
+    }
+
+    /// Builder function that sets the device number.
+    pub fn with_devnum(mut self, devnum: u32) -> Self {
+        self.set_devnum(devnum);
+        self
+    }
+
     /// Gets the slow field.
     pub const fn slow(&self) -> u8 {
         self.slow
+    }
+
+    /// Sets the slow number.
+    pub fn set_slow(&mut self, slow: u8) {
+        self.slow = slow;
+    }
+
+    /// Builder function that sets the slow number.
+    pub fn with_slow(mut self, slow: u8) -> Self {
+        self.set_slow(slow);
+        self
     }
 }
 

--- a/src/types/driver.rs
+++ b/src/types/driver.rs
@@ -1,13 +1,64 @@
 use std::{cmp, fmt};
 
-use crate::USBFS_MAX_DRIVER_NAME;
+use crate::{USBFS_MAX_DRIVER_NAME, USBFS_MAX_DRIVER_NAME_FFI};
+
+/// Represents a USBFS driver name.
+///
+/// The internal representation is a null-terminated byte buffer for C-like strings.
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct DriverName([u8; USBFS_MAX_DRIVER_NAME_FFI]);
+
+impl DriverName {
+    /// Creates a new [DriverName].
+    pub const fn new() -> Self {
+        Self([0u8; USBFS_MAX_DRIVER_NAME_FFI])
+    }
+
+    /// Creates a [DriverName] from a string.
+    ///
+    /// **NOTE** Sets at most [`USBFS_MAX_DRIVER_NAME`] bytes.
+    pub fn from_string(&mut self, driver: &str) {
+        let bytes = driver.as_bytes();
+        // always leave the last byte null for C-like null-terminated strings
+        let len = cmp::min(bytes.len(), USBFS_MAX_DRIVER_NAME);
+
+        self.0[..len].copy_from_slice(&bytes[..len]);
+        self.0[len..].copy_from_slice(&[0u8; USBFS_MAX_DRIVER_NAME_FFI][len..]);
+    }
+
+    /// Gets a [`&str`] representation of the [DriverName].
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(self.0.as_ref()).unwrap_or("")
+    }
+}
+
+impl From<&str> for DriverName {
+    fn from(val: &str) -> Self {
+        let mut ret = Self::new();
+        ret.from_string(val);
+        ret
+    }
+}
+
+impl Default for DriverName {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for DriverName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, r#""{}""#, self.as_str())
+    }
+}
 
 /// Represents an argument to get a USBFS driver from an `ioctl`.
 #[repr(C)]
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct UsbfsGetDriver {
     interface: u32,
-    driver: [u8; USBFS_MAX_DRIVER_NAME + 1],
+    driver: DriverName,
 }
 
 impl UsbfsGetDriver {
@@ -15,7 +66,15 @@ impl UsbfsGetDriver {
     pub const fn new() -> Self {
         Self {
             interface: 0,
-            driver: [0u8; USBFS_MAX_DRIVER_NAME + 1],
+            driver: DriverName::new(),
+        }
+    }
+
+    /// Creates a new [UsbfsGetDriver] from the provided parameters.
+    pub fn create(interface: u32, driver: &str) -> Self {
+        Self {
+            interface,
+            driver: DriverName::from(driver),
         }
     }
 
@@ -24,20 +83,32 @@ impl UsbfsGetDriver {
         self.interface
     }
 
+    /// Sets the interface.
+    pub fn set_interface(&mut self, interface: u32) {
+        self.interface = interface;
+    }
+
+    /// Builder function that sets the interface.
+    pub fn with_interface(mut self, interface: u32) -> Self {
+        self.set_interface(interface);
+        self
+    }
+
     /// Gets the driver name.
     pub fn driver(&self) -> &str {
-        std::str::from_utf8(self.driver.as_ref()).unwrap_or("")
+        self.driver.as_str()
     }
 
     /// Sets the driver name.
+    ///
+    /// **NOTE** Sets at most [`USBFS_MAX_DRIVER_NAME`] bytes.
     pub fn set_driver(&mut self, driver: &str) {
-        let dbytes = driver.as_bytes();
-        let len = cmp::min(dbytes.len(), USBFS_MAX_DRIVER_NAME);
-
-        self.driver[..len].copy_from_slice(&dbytes[..len]);
+        self.driver.from_string(driver);
     }
 
     /// Builder function that sets the driver name.
+    ///
+    /// **NOTE** Sets at most [`USBFS_MAX_DRIVER_NAME`] bytes.
     pub fn with_driver(mut self, driver: &str) -> Self {
         self.set_driver(driver);
         self
@@ -54,7 +125,7 @@ impl fmt::Display for UsbfsGetDriver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
         write!(f, r#""interface": {}, "#, self.interface)?;
-        write!(f, r#""driver": "{}""#, self.driver())?;
+        write!(f, r#""driver": {}"#, self.driver)?;
         write!(f, "}}")
     }
 }

--- a/src/types/interface.rs
+++ b/src/types/interface.rs
@@ -17,9 +17,33 @@ impl UsbfsSetInterface {
         }
     }
 
+    /// Creates a new [UsbfsSetInterface] from the provided parameters.
+    pub const fn create(interface: u32, altsetting: u32) -> Self {
+        Self {
+            interface,
+            altsetting,
+        }
+    }
+
     /// Gets the interface.
     pub const fn interface(&self) -> u32 {
         self.interface
+    }
+
+    /// Gets a mutable reference to the interface.
+    pub fn interface_mut(&mut self) -> &mut u32 {
+        &mut self.interface
+    }
+
+    /// Sets the interface.
+    pub fn set_interface(&mut self, interface: u32) {
+        self.interface = interface;
+    }
+
+    /// Sets the interface.
+    pub fn with_interface(mut self, interface: u32) -> Self {
+        self.set_interface(interface);
+        self
     }
 
     /// Gets the altsetting.

--- a/tests/usbfs.rs
+++ b/tests/usbfs.rs
@@ -1,0 +1,207 @@
+use usbfs::*;
+
+// FIXME: currently returns a constant, it should dynamically detect a valid USB file descriptor.
+//
+// Most relevant is the CI context, where a pseudo-device needs to be mocked for deterministic tests.
+fn get_usb_fd() -> i32 {
+    0
+}
+
+#[test]
+fn test_control() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut control = UsbfsCtrlTransfer::new()
+        // ENDPOINT_IN
+        .with_request_type(0x80)
+        // USB_GET_CONFIGURATION
+        .with_request(0x08)
+        .with_timeout(1000)
+        .with_data([0u8]);
+
+    usbfs_control(fd, &mut control).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_set_release_iface() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut set_iface = UsbfsSetInterface::create(1, 0);
+
+    usbfs_set_interface(fd, &mut set_iface).ok();
+    usbfs_claim_interface(fd, set_iface.interface_mut()).ok();
+    usbfs_release_interface(fd, set_iface.interface_mut()).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_set_configuration() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut config = 0u32;
+
+    usbfs_set_configuration(fd, &mut config).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_get_driver() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut driver = UsbfsGetDriver::new().with_interface(0);
+
+    usbfs_get_driver(fd, &mut driver).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_submit_urb() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut urb = Urb::new()
+        // URB_TYPE_CONTROL
+        .with_urb_type(2)
+        .with_buffer([0; 4]);
+
+    usbfs_submit_urb(fd, &mut urb).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_discard_urb() -> Result<()> {
+    let fd = get_usb_fd();
+
+    usbfs_discard_urb(fd).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_reap_urb_ndelay() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut urb = Urb::new()
+        // URB_TYPE_CONTROL
+        .with_urb_type(2)
+        .with_buffer([0; 4]);
+
+    usbfs_reap_urb_ndelay(fd, &mut urb).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_connect_info() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut info = UsbfsConnectInfo::create(1, 42);
+
+    usbfs_connect_info(fd, &mut info).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_ioctl() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut ioctl = UsbfsIoctl::new().with_ifno(1).with_ioctl_code(18);
+
+    usbfs_ioctl(fd, &mut ioctl).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_reset() -> Result<()> {
+    let fd = get_usb_fd();
+
+    usbfs_reset(fd).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_clear_halt() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut iface = 1u32;
+
+    usbfs_clear_halt(fd, &mut iface).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_disconnect() -> Result<()> {
+    let fd = get_usb_fd();
+
+    usbfs_disconnect(fd).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_connect() -> Result<()> {
+    let fd = get_usb_fd();
+
+    usbfs_connect(fd).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_get_capabilities() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut iface = 1u32;
+
+    usbfs_get_capabilities(fd, &mut iface).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_disconnect_claim() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut claim = UsbfsDisconnectClaim::new();
+
+    usbfs_disconnect_claim(fd, &mut claim).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_alloc_streams() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut streams = UsbfsStreams::new();
+
+    usbfs_alloc_streams(fd, &mut streams).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_free_streams() -> Result<()> {
+    let fd = get_usb_fd();
+    let mut streams = UsbfsStreams::new();
+
+    usbfs_free_streams(fd, &mut streams).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_drop_privileges() -> Result<()> {
+    let fd = get_usb_fd();
+    let privileges = 0u64;
+
+    usbfs_drop_privileges(fd, privileges).ok();
+
+    Ok(())
+}
+
+#[test]
+fn test_get_speed() -> Result<()> {
+    let fd = get_usb_fd();
+
+    usbfs_get_speed(fd).ok();
+
+    Ok(())
+}


### PR DESCRIPTION
Adds a basic test suite for the library.

Tests that functions complete successfully without crashing the test runner. A more advanced test suite will include a mock USB device, capable of spawning a USB entry in CI environments.

Fills out type APIs for publicly exposed library types.