### PR TITLE
lib: add publishing information

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,15 @@
 name = "usbfs"
 version = "0.1.0"
 edition = "2021"
+authors = ["USBFS Rust developers"]
+description = "An XML library in pure Rust"
+repository = "https://github.com/kornelski/xml-rs"
+homepage = "https://crates.io/crates/usbfs"
+documentation = "https://docs.rs/usbfs/"
+readme = "README.md"
+license = "MIT"
+keywords = ["usbfs", "linux", "usb"]
+categories = ["os", "os::linux-apis"]
 
 [dependencies.nix]
 version = "0.27"


### PR DESCRIPTION
Adds basic crate publishing information to `Cargo.toml`.